### PR TITLE
Fix GetReport bug.

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -1017,6 +1017,7 @@ class MWSClient
                     $reader->setHeaderOffset(0);
                     $headers = $reader->getHeader();
                     $statement = new \League\Csv\Statement;
+                    $result = array();
                     foreach ($statement->process($reader) as $row) {
                         $result[] = array_combine($headers, $row);
                     }


### PR DESCRIPTION
Fixes this error when getting a report.
Fatal error: Uncaught Exception: Key ReportRequestIdList.Id.1[0] must be all numbers if it starts with an integer in /vendor/mcs/amazon-mws/src/MWSClient.php:1441
Stack trace:
#0 /vendor/mcs/amazon-mws/src/MWSClient.php(1041): MCS\MWSClient->request(Array, Array)
#1 /vendor/mcs/amazon-mws/src/MWSClient.php(1006): MCS\MWSClient->GetReportRequestStatus(Array)
#2 /scripts/amazon/amazon.class.php(184): MCS\MWSClient->GetReport(Array)
#5 {main}
  thrown in /vendor/mcs/amazon-mws/src/MWSClient.php on line 1441