### PR TITLE
New validateCredentials Message

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -88,7 +88,7 @@ class MWSClient
         try {
             $this->ListOrderItems('validate');
         } catch (Exception $e) {
-            if ($e->getMessage() == 'Invalid AmazonOrderId: validate' || $e->getMessage() == 'The order id you have requested is not valid') {
+            if ($e->getMessage() == 'Invalid AmazonOrderId: validate' || $e->getMessage() == 'The order id you have requested is not valid.') {
                 return true;
             } else {
                 return false;

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -88,7 +88,7 @@ class MWSClient
         try {
             $this->ListOrderItems('validate');
         } catch (Exception $e) {
-            if ($e->getMessage() == 'Invalid AmazonOrderId: validate') {
+            if ($e->getMessage() == 'Invalid AmazonOrderId: validate' || $e->getMessage() == 'The order id you have requested is not valid') {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
It says now 'The order id you have requested is not valid' instead of 'Invalid AmazonOrderId: validate'
This is just a quick fix and should be catched another way, because this string can change anytime in the future and break this function again.